### PR TITLE
post install to create and link to a new dir for versions

### DIFF
--- a/Formula/gmenv.rb
+++ b/Formula/gmenv.rb
@@ -14,6 +14,15 @@ class Gmenv < Formula
 #     prefix.install "lib" if build.head?
   end
 
+  def post_install
+    versions_path = HOMEBREW_PREFIX/"etc/#{name}/versions"
+    versions_local = "#{prefix}/versions"
+
+    mkdir_p versions_path unless versions_path.directory?
+
+    ln_s versions_path, versions_local
+  end
+
   test do
     system bin/"gmenv", "--version"
   end


### PR DESCRIPTION
Before this change, the Grey Matter binaries are stored in a versions folder under the gmenv version folder. Every time an update was made, the verions would be lost and have to be redownloaded. This creates a directory in homebrew etc path, which is common practice. It then performs a soft link to the local verions directory